### PR TITLE
Add next links and fix small typo

### DIFF
--- a/src/tutorial/om_tutorial/B_UI.cljs
+++ b/src/tutorial/om_tutorial/B_UI.cljs
@@ -220,4 +220,6 @@
   - Add parent-generated things (like callbacks) using `om/computed`.
 
   TODO: Add links to various docs
+
+  [Now let's try some exercises.](#!/om_tutorial.B_UI_Exercises)
   ")

--- a/src/tutorial/om_tutorial/B_UI_Exercises.cljs
+++ b/src/tutorial/om_tutorial/B_UI_Exercises.cljs
@@ -221,3 +221,5 @@
                          {:db/id 1 :person/name "Joe" :person/mate {:db/id 2 :person/name "Sally"}}
                          {:db/id 2 :person/name "Sally" :person/mate {:db/id 1 :person/name "Joe"}}]}}
   {:inspect-data true})
+
+(defcard-doc "[Next: App Database](#!/om_tutorial.C_App_Database)")

--- a/src/tutorial/om_tutorial/C_App_Database.cljs
+++ b/src/tutorial/om_tutorial/C_App_Database.cljs
@@ -149,5 +149,7 @@
 
   If you chose to use an alternate database format, _then_ you'll have to manage the normalization
   among other things (like merging in novelty).
+
+  [Let's try some exercises.](#!/om_tutorial.C_App_Database_Exercises)
   ")
 

--- a/src/tutorial/om_tutorial/C_App_Database.cljs
+++ b/src/tutorial/om_tutorial/C_App_Database.cljs
@@ -147,7 +147,7 @@
   the UI query to reformat that data into the internal database format. We'll see more
   on that after we talk about queries.
 
-  If you chose to use an alternate database format, _then_ you'll have to manage the normalization
+  If you choose to use an alternate database format, _then_ you'll have to manage the normalization
   among other things (like merging in novelty).
 
   [Let's try some exercises.](#!/om_tutorial.C_App_Database_Exercises)

--- a/src/tutorial/om_tutorial/C_App_Database_Exercises.cljs
+++ b/src/tutorial/om_tutorial/C_App_Database_Exercises.cljs
@@ -70,3 +70,6 @@
            :canvas  {:data [{:x 1, :y 3}]}}}
         (om/db->tree '[{:main-panel [{:toolbar [{:tools [:label]}]}
                                      {:canvas [{:data [:x :y]}]}]}] ex3-uidb ex3-uidb))))
+
+(defcard-doc
+  "[Next: Queries](#!/om_tutorial.D_Queries)")

--- a/src/tutorial/om_tutorial/D_Queries.cljs
+++ b/src/tutorial/om_tutorial/D_Queries.cljs
@@ -286,4 +286,6 @@
   (obviously) understand the basic bits of query syntax and retrieve data. It is insufficient
   for the full guts of a real application, but it is a wonderful helper that greatly simplifies
   the task.
+
+  [Next: State Reads and Parsing](#!/om_tutorial.E_State_Reads_and_Parsing)
   ")

--- a/src/tutorial/om_tutorial/E_State_Reads_and_Parsing.cljs
+++ b/src/tutorial/om_tutorial/E_State_Reads_and_Parsing.cljs
@@ -577,3 +577,8 @@ Try some queries like these:
     "
     (is (= {[:people/by-id 1] {:person/name "Sam", :person/mate {:person/name "Jenny"}}}
           (om/db->tree '[{[:people/by-id 1] [:person/name {:person/mate [:person/name]}]}] app-state app-state)))))
+
+(defcard-doc
+  "
+  [Next: Exercises](#!/om_tutorial.E_State_Reads_and_Parsing_Exercises)
+  ")

--- a/src/tutorial/om_tutorial/E_State_Reads_and_Parsing_Exercises.cljs
+++ b/src/tutorial/om_tutorial/E_State_Reads_and_Parsing_Exercises.cljs
@@ -27,5 +27,7 @@
   - recursive examples?
   - Look at the AST for bits
 
+
+  [Next: UI Queries and State](#!/om_tutorial.E_UI_Queries_and_State)
   ")
 

--- a/src/tutorial/om_tutorial/E_UI_Queries_and_State.cljs
+++ b/src/tutorial/om_tutorial/E_UI_Queries_and_State.cljs
@@ -186,4 +186,6 @@
   Sometimes you're just trying to clean up code and factor bits out. Don't feel like you have to wrap UI code in
   `defui` if it doesn't need any support from React or Om. Just write a function! `PeopleWidget` earlier in this
   document is a great example of this.
+
+  [Next: Exercises](#!/om_tutorial.E_UI_Queries_and_State_Exercises)
   ")

--- a/src/tutorial/om_tutorial/E_UI_Queries_and_State_Exercises.cljs
+++ b/src/tutorial/om_tutorial/E_UI_Queries_and_State_Exercises.cljs
@@ -103,3 +103,6 @@ TODO: Split this into smaller bits.
    :widget     {:people [{:person/name "Joe" :db/id 1 :person/mate {:person/name "Sally" :db/id 2}}
                          {:person/name "Sally" :db/id 2 :person/mate {:person/name "Joe" :db/id 1}}]}}
   {:inspect-data true})
+
+(defcard-doc
+  "[Next: Mutation](#!/om_tutorial.F_Mutation)")

--- a/src/tutorial/om_tutorial/F_Mutation.cljs
+++ b/src/tutorial/om_tutorial/F_Mutation.cljs
@@ -156,3 +156,6 @@
   if the state hasn't changed, then React will optimize away any actual DOM change.
   ")
 
+(defcard-doc
+  "[Next: Excercises](#!/om_tutorial.F_Mutation_Exercises)")
+

--- a/src/tutorial/om_tutorial/F_Mutation_Exercises.cljs
+++ b/src/tutorial/om_tutorial/F_Mutation_Exercises.cljs
@@ -15,4 +15,5 @@
      - Demonstrate how top-level transactions become trivial when everything is in top-level tables
      - Show how many UI-specific mutation concerns can then be combined into a small set of functions
 
+  [Next: Remote Fetch](#!/om_tutorial.G_Remote_Fetch)
   ")

--- a/src/tutorial/om_tutorial/G_Remote_Fetch.cljs
+++ b/src/tutorial/om_tutorial/G_Remote_Fetch.cljs
@@ -154,6 +154,7 @@
   If you look in `om-tutorial.core` you'll see an alternate tempid migration function that doesn't need id-key
   and doesn't throw out potential cached app state.
 
+  [Next: Remote Mutation](#!/om_tutorial.H_Remote_Mutation)
   ")
 
 

--- a/src/tutorial/om_tutorial/H_Remote_Mutation.cljs
+++ b/src/tutorial/om_tutorial/H_Remote_Mutation.cljs
@@ -66,4 +66,5 @@
   - You MUST set `:id-key` on reconciler to the ID key used by the actual objects to be migrated, since the ident need
   not use that key (idents are a client-local concern)
 
+  [Next: Path Optimization](#!/om_tutorial.I_Path_Optimization)
   ")

--- a/src/tutorial/om_tutorial/I_Path_Optimization.cljs
+++ b/src/tutorial/om_tutorial/I_Path_Optimization.cljs
@@ -22,5 +22,7 @@
   When it attempts this kind of read it will call your `read` function with `:query/root` set to the ident of the component that
   is needing re-render, and you will need to follow the query down from there. Fortunately, `db->tree` still works
   for the default database format with a little care.
+
+  [Next: Advanced Queries](#!/om_tutorial.J_Advanced_Queries)
   ")
 


### PR DESCRIPTION
Hi, I've started going through your awesome tutorial, thanks @awkay 

This PR adds a "Next" link to the bottom of the pages.

Also I changed:
"If you chose to use an alternate database format, _then_ you'll have to manage the normalization"
to
"If you _choose_ to use an alternate database format, _then_ you'll have to manage the normalization"

because it matches the "you'll" part.
